### PR TITLE
feat: Full integration of PlaceholderAPI and custom variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.artillexstudios</groupId>
     <artifactId>AxAFKZone</artifactId>
-    <version>1.9.0</version>
+    <version>1.9.1</version>
     <packaging>jar</packaging>
 
     <name>AxAFKZone</name>

--- a/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
@@ -65,6 +65,10 @@ public final class AxAFKZone extends AxPlugin {
         metrics.start();
 
         if (CONFIG.getBoolean("update-notifier.enabled", true)) new UpdateNotifier(this, 6598);
+
+        if (getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new com.artillexstudios.axafkzone.hooks.PlaceholderAPIHook().register();
+        }
     }
 
     public void updateFlags() {

--- a/src/main/java/com/artillexstudios/axafkzone/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/com/artillexstudios/axafkzone/hooks/PlaceholderAPIHook.java
@@ -46,13 +46,13 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
         }
 
         switch (params.toLowerCase()) {
-            case "en_zona":
-                return currentZone != null ? "Si" : "No";
+            case "in_zone":
+                return currentZone != null ? "true" : "false";
 
-            case "zona_actual":
+            case "current_zone":
                 return currentZone != null ? currentZone.getName() : "";
 
-            case "tiempo_transcurrido":
+            case "time_spent":
                 if (currentZone != null) {
                     Integer timeSpent = currentZone.getPlayerTime(p);
                     if (timeSpent != null) {
@@ -61,7 +61,7 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
                 }
                 return "0s";
 
-            case "tiempo_restante":
+            case "time_left":
                 if (currentZone != null) {
                     long timeLeft = currentZone.timeUntilNext(p);
                     if (timeLeft != -1) {
@@ -70,12 +70,12 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
                 }
                 return "0s";
 
-            case "barra_progreso":
-                String symbol = AxAFKZone.CONFIG.getString("placeholder-progress-bar.simbolo", "■");
-                int length = AxAFKZone.CONFIG.getInt("placeholder-progress-bar.longitud", 10);
-                String filledColor = AxAFKZone.CONFIG.getString("placeholder-progress-bar.color-completado", "&#00AAFF");
-                String unfilledColor = AxAFKZone.CONFIG.getString("placeholder-progress-bar.color-faltante", "&7");
-                String format = AxAFKZone.CONFIG.getString("placeholder-progress-bar.formato", "&a[ {bar} &a]");
+            case "progress_bar":
+                String symbol = AxAFKZone.CONFIG.getString("placeholder-progress-bar.symbol", "■");
+                int length = AxAFKZone.CONFIG.getInt("placeholder-progress-bar.length", 10);
+                String filledColor = AxAFKZone.CONFIG.getString("placeholder-progress-bar.filled-color", "&#00AAFF");
+                String unfilledColor = AxAFKZone.CONFIG.getString("placeholder-progress-bar.unfilled-color", "&7");
+                String format = AxAFKZone.CONFIG.getString("placeholder-progress-bar.format", "&a[ {bar} &a]");
 
                 StringBuilder bar = new StringBuilder();
 
@@ -104,6 +104,6 @@ public class PlaceholderAPIHook extends PlaceholderExpansion {
                 return com.artillexstudios.axapi.utils.StringUtils.formatToString(format.replace("{bar}", bar.toString()));
         }
 
-        return null; // Variable no reconocida
+        return null; // Variable not recognized
     }
 }

--- a/src/main/java/com/artillexstudios/axafkzone/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/com/artillexstudios/axafkzone/hooks/PlaceholderAPIHook.java
@@ -1,0 +1,109 @@
+package com.artillexstudios.axafkzone.hooks;
+
+import com.artillexstudios.axafkzone.AxAFKZone;
+import com.artillexstudios.axafkzone.utils.TimeUtils;
+import com.artillexstudios.axafkzone.zones.Zone;
+import com.artillexstudios.axafkzone.zones.Zones;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class PlaceholderAPIHook extends PlaceholderExpansion {
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "axafkzone";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "Artillex-Studios";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return AxAFKZone.getInstance().getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, @NotNull String params) {
+        if (player == null || !player.isOnline()) return "";
+        Player p = player.getPlayer();
+        if (p == null) return "";
+
+        Zone currentZone = null;
+        for (Zone zone : Zones.getZones().values()) {
+            if (zone.getPlayerTime(p) != null) {
+                currentZone = zone;
+                break;
+            }
+        }
+
+        switch (params.toLowerCase()) {
+            case "en_zona":
+                return currentZone != null ? "Si" : "No";
+
+            case "zona_actual":
+                return currentZone != null ? currentZone.getName() : "";
+
+            case "tiempo_transcurrido":
+                if (currentZone != null) {
+                    Integer timeSpent = currentZone.getPlayerTime(p);
+                    if (timeSpent != null) {
+                        return TimeUtils.fancyTime(timeSpent * 1000L);
+                    }
+                }
+                return "0s";
+
+            case "tiempo_restante":
+                if (currentZone != null) {
+                    long timeLeft = currentZone.timeUntilNext(p);
+                    if (timeLeft != -1) {
+                        return TimeUtils.fancyTime(timeLeft);
+                    }
+                }
+                return "0s";
+
+            case "barra_progreso":
+                String symbol = AxAFKZone.CONFIG.getString("placeholder-progress-bar.simbolo", "■");
+                int length = AxAFKZone.CONFIG.getInt("placeholder-progress-bar.longitud", 10);
+                String filledColor = AxAFKZone.CONFIG.getString("placeholder-progress-bar.color-completado", "&#00AAFF");
+                String unfilledColor = AxAFKZone.CONFIG.getString("placeholder-progress-bar.color-faltante", "&7");
+                String format = AxAFKZone.CONFIG.getString("placeholder-progress-bar.formato", "&a[ {bar} &a]");
+
+                StringBuilder bar = new StringBuilder();
+
+                if (currentZone != null) {
+                    Integer timeSpent = currentZone.getPlayerTime(p);
+                    int rewardTime = currentZone.getRewardSeconds();
+                    
+                    if (timeSpent != null && rewardTime > 0) {
+                        int currentCycleTime = timeSpent % rewardTime;
+                        float progress = (float) currentCycleTime / rewardTime;
+                        int filledAmount = Math.max(0, Math.min(length, Math.round(progress * length)));
+                        int unfilledAmount = length - filledAmount;
+                        
+                        bar.append(filledColor);
+                        for (int i = 0; i < filledAmount; i++) bar.append(symbol);
+                        bar.append(unfilledColor);
+                        for (int i = 0; i < unfilledAmount; i++) bar.append(symbol);
+                    }
+                }
+
+                if (bar.length() == 0) {
+                    bar.append(unfilledColor);
+                    for (int i = 0; i < length; i++) bar.append(symbol);
+                }
+
+                return com.artillexstudios.axapi.utils.StringUtils.formatToString(format.replace("{bar}", bar.toString()));
+        }
+
+        return null; // Variable no reconocida
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -282,4 +282,12 @@ public class Zone {
     public int getTicks() {
         return ticks;
     }
+
+    public Integer getPlayerTime(Player player) {
+        return zonePlayers.get(player);
+    }
+
+    public int getRewardSeconds() {
+        return rewardSeconds;
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,15 +35,15 @@ update-notifier:
   # if enabled, it will broadcast the update message to all players who have the <plugin-name>.update-notify permission
   on-join: true
 
-# Configuración visual de la barra de progreso de PlaceholderAPI
-# Los colores se parsean internamente con formato hexagonal/MiniMessage
+# visual configuration for the placeholderapi progress bar
+# colors are parsed internally like the rest of the plugin
 placeholder-progress-bar:
-  simbolo: "■"
-  longitud: 10
-  color-completado: "&#00AAFF"
-  color-faltante: "&7"
-  # variables disponibles: {bar} = Representa el símbolo de la barra generada
-  formato: "&a[ {bar} &a]"
+  symbol: "■"
+  length: 10
+  filled-color: "&#00AAFF"
+  unfilled-color: "&7"
+  # variables: {bar} = The actual bar symbol
+  format: "&a[ {bar} &a]"
 
 # do not change this
 version: 2

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,5 +35,15 @@ update-notifier:
   # if enabled, it will broadcast the update message to all players who have the <plugin-name>.update-notify permission
   on-join: true
 
+# Configuración visual de la barra de progreso de PlaceholderAPI
+# Los colores se parsean internamente con formato hexagonal/MiniMessage
+placeholder-progress-bar:
+  simbolo: "■"
+  longitud: 10
+  color-completado: "&#00AAFF"
+  color-faltante: "&7"
+  # variables disponibles: {bar} = Representa el símbolo de la barra generada
+  formato: "&a[ {bar} &a]"
+
 # do not change this
 version: 2


### PR DESCRIPTION
## 📌 What was implemented?
This Pull Request includes primary support for PlaceholderAPI, which allows other plugins to visually interact with the progress data in AxAFKZone.

### 🌟 Changes made
- Creation of a `PlaceholderAPIHook` under active plugin validation.
- Support for informational variables of the player's global status (whether they are active in the AFK zone or not, their remaining time, elapsed time in iteration, and zone name).
- Creation of a **Dynamic Progress Bar guided by the % of remaining time** in their current AFK cycle.

### ⚙️ Configuration Modifications
The visual segment to customize the bar has been added in the `config.yml`:
```yaml
placeholder-progress-bar:
simbolo: "■"
longitud: 10
color-completado: "&#00AAFF"
color-faltante: "&7"
formato: "&a[ {bar} &a]"
```